### PR TITLE
fix: Disable Header logo fade-in/out in non-home pages

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from "react";
 import Logo from "../images/logo.svg";
 import { Link } from "gatsby";
+import { useLocation } from "@gatsbyjs/reach-router";
 
 interface HeaderProps {
   menuLinks: {
     name: string;
-   link: string;
+    link: string;
   }[];
   className?: string;
 }
@@ -15,6 +16,8 @@ const defaultClass = "";
 const Header = ({ menuLinks, className }: HeaderProps) => {
   const headerClass = className || defaultClass;
   const [showLogo, setShowLogo] = useState(false);
+  const location = useLocation();
+  const isHomePage = location.pathname === "/";
 
   useEffect(() => {
     const handleScroll = () => {
@@ -23,13 +26,13 @@ const Header = ({ menuLinks, className }: HeaderProps) => {
     };
 
     // Check if window is available (for SSR compatibility)
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined" && isHomePage) {
       // Set initial state
       handleScroll();
-      window.addEventListener('scroll', handleScroll);
-      return () => window.removeEventListener('scroll', handleScroll);
+      window.addEventListener("scroll", handleScroll);
+      return () => window.removeEventListener("scroll", handleScroll);
     }
-  }, []);
+  }, [isHomePage]);
 
   return (
     <header
@@ -37,10 +40,14 @@ const Header = ({ menuLinks, className }: HeaderProps) => {
         "safe-paddings transition-200 z-50 transition-colors sticky top-0 " +
         headerClass
       }
-      style={{ backgroundColor: 'white' }}
+      style={{ backgroundColor: "white" }}
     >
-      <div className="flex items-center justify-between pt-5 pb-2 w-full px-4">
-        <div className={`transition-opacity duration-300 ${showLogo ? 'opacity-100' : 'opacity-0'}`}>
+      <div className="flex items-center justify-between p-4 w-full">
+        <div
+          className={`transition-opacity duration-300 ${
+            isHomePage && !showLogo ? "opacity-0" : "opacity-100"
+          }`}
+        >
           <Link to="/">
             <img
               src={Logo}
@@ -53,9 +60,13 @@ const Header = ({ menuLinks, className }: HeaderProps) => {
         </div>
         <nav className="mr-4">
           {menuLinks.map((link) => (
-          <Link key={link.name} to={link.link} className="text-gray-800 hover:text-gray-600 text-base font-semibold pl-4">
-            {link.name}
-          </Link>
+            <Link
+              key={link.name}
+              to={link.link}
+              className="text-gray-800 hover:text-gray-600 text-base font-semibold pl-4"
+            >
+              {link.name}
+            </Link>
           ))}
         </nav>
       </div>


### PR DESCRIPTION
This pull request updates the `Header` component to improve its behavior and appearance, especially on the homepage. The changes focus on making the logo visibility responsive to scroll events only on the homepage, and refactoring the code for clarity and SSR compatibility.

**Homepage-specific behavior:**

* Added logic to detect if the current page is the homepage using `useLocation`, and only trigger the scroll-based logo visibility effect on the homepage. [[1]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206R4) [[2]](diffhunk://#diff-8387d64f5b5e50e1e386a42e75a377d0d8bf6d40a149697aca42cfeda4c8c206R19-R20)
* Updated the scroll event handling in the `useEffect` to run only when on the homepage, improving SSR compatibility and preventing unnecessary event listeners on other pages.

**UI and code refactoring:**

* Refactored the logo's opacity logic so that it fades in or out based on both homepage status and scroll state, improving user experience.
* Cleaned up JSX structure and formatting for better readability, including consistent use of double quotes and improved navigation link rendering.
* Adjusted header component padding to be consistent and thus more visually appealing.