### PR TITLE
fix: Visual tweaks in Convince Your Boss page

### DIFF
--- a/src/pages/convince-your-boss.tsx
+++ b/src/pages/convince-your-boss.tsx
@@ -145,7 +145,7 @@ const ConvinceYourBossPage: React.FC<PageProps> = () => {
                   <strong>Per Diem (2 days):</strong> DKK 700.00
                 </li>
                 <li className="font-bold mt-4">
-                  Total: approx. DKK 5,364.00 – 5,814.00
+                  Total: ~ DKK 5,364.00 – 5,814.00
                 </li>
               </ul>
             </div>
@@ -165,10 +165,10 @@ const ConvinceYourBossPage: React.FC<PageProps> = () => {
                   2,790.00
                 </li>
                 <li>
-                  <strong>Per Diems (2 people, 2 days):</strong> DKK 1,400.00
+                  <strong>Per Diems (2 days):</strong> DKK 1,400.00
                 </li>
                 <li className="font-bold mt-4">
-                  Total: approx. DKK 7,478.00 – 8,378.00
+                  Total: ~ DKK 7,478.00 – 8,378.00
                 </li>
               </ul>
             </div>
@@ -237,9 +237,8 @@ const ConvinceYourBossPage: React.FC<PageProps> = () => {
                 <br />
                 <br />
                 The total estimated investment is [Insert Total from Scenario 1
-                or 2, e.g., approx. DKK 5,364.00]. I have a full itemized cost
-                breakdown prepared (including all travel, per diem, and hotel
-                details) that I can send over.
+                or 2]. I have a full itemized cost breakdown prepared (including
+                all travel, per diem, and hotel details) that I can send over.
                 <br />
                 <br />
                 Can we please discuss this next week when you have time?


### PR DESCRIPTION
This pull request makes several small content and formatting adjustments to the `ConvinceYourBossPage` in `src/pages/convince-your-boss.tsx`. The changes focus on improving text alignment, clarifying cost descriptions, and making the budget summary language more concise.

Content and formatting improvements:

* Changed text alignment for main content and budget example boxes to improve readability, using `text-left` on smaller screens and for certain sections. [[1]](diffhunk://#diff-8e70554af5e90eb65a067c5bfdb6d9750a61a809ec2450284819c46a210c879eL10-R10) [[2]](diffhunk://#diff-8e70554af5e90eb65a067c5bfdb6d9750a61a809ec2450284819c46a210c879eL203-R203)
* Updated cost summary lines to use `~` instead of `approx.` for a more concise presentation. [[1]](diffhunk://#diff-8e70554af5e90eb65a067c5bfdb6d9750a61a809ec2450284819c46a210c879eL148-R148) [[2]](diffhunk://#diff-8e70554af5e90eb65a067c5bfdb6d9750a61a809ec2450284819c46a210c879eL168-R171)
* Clarified "Per Diems" descriptions to remove redundancy and improve clarity.
* Simplified the sample email template by removing the "approx." language and making the total investment statement more generic.