### PR TITLE
feat: Improve Schedule Page UX for Mobile Devices

### DIFF
--- a/src/components/session_modal.tsx
+++ b/src/components/session_modal.tsx
@@ -5,11 +5,7 @@ const SessionModal: React.FC<{
   session: Session;
   onClose: () => void;
   onSpeakerClick: (speaker: Speaker) => void;
-}> = ({
-  session,
-  onClose,
-  onSpeakerClick,
-}) => {
+}> = ({ session, onClose, onSpeakerClick }) => {
   const starts = new Date(session.startsAt);
   const ends = new Date(session.endsAt);
   const duration = (ends.getTime() - starts.getTime()) / (1000 * 60); // duration in minutes
@@ -23,71 +19,100 @@ const SessionModal: React.FC<{
   };
 
   React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
     document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+
     return () => {
       document.body.style.overflow = "unset";
+      document.removeEventListener("keydown", handleKeyDown);
     };
-  }, []);
+  }, [onClose]);
 
   return (
     <>
       <div
-        className="fixed inset-0 bg-white z-40" style={{opacity: 0.5}}
+        className="fixed inset-0 bg-white z-40"
+        style={{ opacity: 0.5 }}
         onClick={onClose}
       ></div>
       <div
-        className="fixed inset-0 z-50 flex justify-center items-center p-4"
+        className="fixed inset-x-0 bottom-0 z-50 flex justify-center items-center p-4"
+        style={{ top: "76px" }}
         onClick={onClose}
       >
         <div
-          className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto p-8 relative"
+          className="bg-white rounded-lg shadow-2xl max-w-2xl w-full max-h-full flex flex-col relative border border-gray-200"
           onClick={(e) => e.stopPropagation()}
         >
-          <button
-            onClick={onClose}
-            className="absolute top-4 right-4 text-gray-500 hover:text-gray-800 text-3xl leading-none"
-          >
-            &times;
-          </button>
+          <div className="overflow-y-auto p-8 flex-grow">
+            <h2 className="text-3xl font-bold text-primary mb-4">
+              {session.title || session.name}
+            </h2>
 
-          <h2 className="text-3xl font-bold text-primary mb-4">
-            {session.title || session.name}
-          </h2>
+            <div className="flex flex-wrap gap-x-6 gap-y-2 text-gray-600 mb-6">
+              <span>
+                <strong>Time:</strong> {formatTime(session.startsAt)} -{" "}
+                {formatTime(session.endsAt)} ({duration} min)
+              </span>
+              <span>
+                <strong>Room:</strong> {session.room}
+              </span>
+            </div>
 
-          <div className="flex flex-wrap gap-x-6 gap-y-2 text-gray-600 mb-6">
-            <span>
-              <strong>Time:</strong> {formatTime(session.startsAt)} -{" "}
-              {formatTime(session.endsAt)} ({duration} min)
-            </span>
-            <span>
-              <strong>Room:</strong> {session.room}
-            </span>
+            {session.speakers && session.speakers.length > 0 && (
+              <div className="mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-3">
+                  Speakers
+                </h3>
+                <div className="flex flex-wrap gap-6">
+                  {session.speakers.map((speaker) => (
+                    <div
+                      key={speaker.id}
+                      className="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity"
+                      onClick={() => onSpeakerClick(speaker)}
+                    >
+                      <img
+                        src={speaker.profilePicture}
+                        alt={speaker.fullName}
+                        className="w-16 h-16 rounded-full object-cover shadow-md"
+                      />
+                      <span className="font-semibold text-gray-700">
+                        {speaker.fullName}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {session.description && (
+              <div>
+                <h3 className="text-xl font-bold text-gray-800 mb-3">
+                  Description
+                </h3>
+                <div
+                  className="text-gray-700 space-y-4"
+                  dangerouslySetInnerHTML={{ __html: session.description }}
+                />
+              </div>
+            )}
           </div>
 
-          {session.speakers && session.speakers.length > 0 && (
-            <div className="mb-6">
-              <h3 className="text-xl font-bold text-gray-800 mb-3">Speakers</h3>
-              <div className="flex flex-wrap gap-6">
-                {session.speakers.map((speaker) => (
-                  <div
-                    key={speaker.id}
-                    className="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity"
-                    onClick={() => onSpeakerClick(speaker)}
-                  >
-                    <img src={speaker.profilePicture} alt={speaker.fullName} className="w-16 h-16 rounded-full object-cover shadow-md" />
-                    <span className="font-semibold text-gray-700">{speaker.fullName}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {session.description && (
-            <div>
-              <h3 className="text-xl font-bold text-gray-800 mb-3">Description</h3>
-              <div className="text-gray-700 space-y-4" dangerouslySetInnerHTML={{ __html: session.description }} />
-            </div>
-          )}
+          <div className="px-8 py-4 sm:pb-6 text-center bg-white flex-shrink-0 relative">
+            <div className="absolute bottom-full left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent pointer-events-none"></div>
+            <button
+              onClick={onClose}
+              className="bg-background hover:bg-hover text-white font-semibold py-3 px-8 rounded-full text-lg transition-colors duration-200"
+            >
+              Back to Schedule
+            </button>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/speaker_modal.tsx
+++ b/src/components/speaker_modal.tsx
@@ -6,69 +6,84 @@ const SpeakerModal: React.FC<{ speaker: Speaker; onClose: () => void }> = ({
   onClose,
 }) => {
   React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
     document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+
     return () => {
       document.body.style.overflow = "unset";
+      document.removeEventListener("keydown", handleKeyDown);
     };
-  }, []);
+  }, [onClose]);
 
   return (
     <>
       <div
-        className="fixed inset-0 bg-white z-40" style={{opacity: 0.5}}
+        className="fixed inset-0 bg-white z-50"
+        style={{ opacity: 0.5 }}
         onClick={onClose}
       ></div>
       <div
-        className="fixed inset-0 z-50 flex justify-center items-center p-4"
+        className="fixed inset-x-0 bottom-0 z-50 flex justify-center items-center p-4"
+        style={{ top: "76px" }}
         onClick={onClose}
       >
         <div
-          className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto p-8 relative"
+          className="bg-white rounded-lg border border-gray-200 shadow-2xl max-w-2xl w-full max-h-full flex flex-col relative"
           onClick={(e) => e.stopPropagation()}
         >
-          <button
-            onClick={onClose}
-            className="absolute top-4 right-4 text-gray-500 hover:text-gray-800 text-3xl leading-none"
-          >
-            &times;
-          </button>
-
-          <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 mb-6">
-            <img
-              src={speaker.profilePicture}
-              alt={speaker.fullName}
-              className="w-32 h-32 rounded-full object-cover shadow-md flex-shrink-0"
-            />
-            <div className="text-center sm:text-left">
-              <h2 className="text-3xl font-bold text-primary mb-2">
-                {speaker.fullName}
-              </h2>
-              <p className="text-lg text-gray-600">{speaker.tagLine}</p>
-            </div>
-          </div>
-
-          {speaker.bio && (
-            <div className="mb-6">
-              <h3 className="text-xl font-bold text-gray-800 mb-3">About</h3>
-              <div
-                className="text-gray-700 space-y-4"
-                dangerouslySetInnerHTML={{ __html: speaker.bio }}
+          <div className="overflow-y-auto p-8 flex-grow">
+            <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 mb-6">
+              <img
+                src={speaker.profilePicture}
+                alt={speaker.fullName}
+                className="w-32 h-32 rounded-full object-cover shadow-md flex-shrink-0"
               />
+              <div className="text-center sm:text-left">
+                <h2 className="text-3xl font-bold text-primary mb-2">
+                  {speaker.fullName}
+                </h2>
+                <p className="text-lg text-gray-600">{speaker.tagLine}</p>
+              </div>
             </div>
-          )}
 
-          {speaker.sessions && speaker.sessions.length > 0 && (
-            <div>
-              <h3 className="text-xl font-bold text-gray-800 mb-3">
-                Sessions
-              </h3>
-              <ul className="list-disc list-inside text-gray-700 space-y-2">
-                {speaker.sessions.map((session) => (
-                  <li key={session.id}>{session.name}</li>
-                ))}
-              </ul>
-            </div>
-          )}
+            {speaker.bio && (
+              <div className="mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-3">About</h3>
+                <div
+                  className="text-gray-700 space-y-4"
+                  dangerouslySetInnerHTML={{ __html: speaker.bio }}
+                />
+              </div>
+            )}
+
+            {speaker.sessions && speaker.sessions.length > 0 && (
+              <div>
+                <h3 className="text-xl font-bold text-gray-800 mb-3">
+                  Sessions
+                </h3>
+                <ul className="list-disc list-inside text-gray-700 space-y-2">
+                  {speaker.sessions.map((session) => (
+                    <li key={session.id}>{session.name}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+          <div className="px-8 py-4 sm:pb-6 text-center bg-white flex-shrink-0 relative">
+            <div className="absolute bottom-full left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent pointer-events-none"></div>
+            <button
+              onClick={onClose}
+              className="bg-background hover:bg-hover text-white font-semibold py-3 px-8 rounded-full text-lg transition-colors duration-200"
+            >
+              Back to Talk
+            </button>
+          </div>
         </div>
       </div>
     </>

--- a/src/pages/schedule.tsx
+++ b/src/pages/schedule.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 import { type HeadFC, type PageProps } from "gatsby";
 import Layout from "../components/layout";
 import SEO from "../components/seo";
-import { useSessionizeSchedule, type Session, type Speaker } from "../hooks/use-sessionize";
+import {
+  useSessionizeSchedule,
+  type Session,
+  type Speaker,
+} from "../hooks/use-sessionize";
 import SessionModal from "../components/session_modal";
 import SpeakerModal from "../components/speaker_modal";
 
@@ -16,8 +20,10 @@ const SessionCard: React.FC<{ session: Session; onClick?: () => void }> = ({
 
   if (session.isServiceSession) {
     return (
-      <div className="bg-gray-100 p-4 h-full flex items-center justify-center text-center rounded-lg border border-gray-200">
-        <h3 className="font-bold text-lg text-gray-700">{session.title || session.name}</h3>
+      <div className="bg-gray-100 p-4 h-full flex items-center justify-center text-center rounded-lg border border-gray-300">
+        <h3 className="font-bold text-lg text-gray-700">
+          {session.title || session.name}
+        </h3>
       </div>
     );
   }
@@ -28,7 +34,9 @@ const SessionCard: React.FC<{ session: Session; onClick?: () => void }> = ({
       onClick={onClick}
     >
       <div>
-        <h3 className="font-bold text-md text-primary">{session.title || session.name}</h3>
+        <h3 className="font-bold text-md text-primary">
+          {session.title || session.name}
+        </h3>
         {session.speakers && session.speakers.length > 0 && (
           <p className="text-sm text-gray-600 mt-2">
             <em>{session.speakers.map((s) => s.fullName).join(", ")}</em>
@@ -41,8 +49,12 @@ const SessionCard: React.FC<{ session: Session; onClick?: () => void }> = ({
 
 const SchedulePage: React.FC<PageProps> = () => {
   const { schedule } = useSessionizeSchedule();
-  const [selectedSession, setSelectedSession] = React.useState<Session | null>(null);
-  const [selectedSpeaker, setSelectedSpeaker] = React.useState<Speaker | null>(null);
+  const [selectedSession, setSelectedSession] = React.useState<Session | null>(
+    null
+  );
+  const [selectedSpeaker, setSelectedSpeaker] = React.useState<Speaker | null>(
+    null
+  );
 
   React.useEffect(() => {
     if (schedule.length > 0 && typeof window !== "undefined") {
@@ -72,7 +84,11 @@ const SchedulePage: React.FC<PageProps> = () => {
   const handleCloseSessionModal = () => {
     setSelectedSession(null);
     setSelectedSpeaker(null);
-    window.history.pushState(null, "", window.location.pathname + window.location.search);
+    window.history.pushState(
+      null,
+      "",
+      window.location.pathname + window.location.search
+    );
   };
 
   const formatDate = (dateString: string) => {
@@ -84,7 +100,7 @@ const SchedulePage: React.FC<PageProps> = () => {
   };
 
   const formatTime = (timeString: string) => {
-    return timeString.substring(0, timeString.lastIndexOf(':'))
+    return timeString.substring(0, timeString.lastIndexOf(":"));
   };
 
   return (
@@ -99,7 +115,7 @@ const SchedulePage: React.FC<PageProps> = () => {
         </div>
       </section>
 
-      <section className="py-16 bg-white">
+      <section className="py-12 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           {schedule.length === 0 && (
             <div className="text-center">
@@ -107,21 +123,50 @@ const SchedulePage: React.FC<PageProps> = () => {
             </div>
           )}
 
+          {schedule.length > 0 && (
+            <div className="flex justify-center space-x-4">
+              {schedule.map((day) => (
+                <button
+                  key={day.date}
+                  onClick={() => {
+                    const element = document.getElementById(day.date);
+                    if (element) {
+                      const elementPosition =
+                        element.getBoundingClientRect().top;
+                      const offsetPosition =
+                        elementPosition + window.pageYOffset - 76;
+
+                      window.scrollTo({
+                        top: offsetPosition,
+                        behavior: "smooth",
+                      });
+                    }
+                  }}
+                  className="bg-background hover:bg-hover text-white text-l font-semibold py-3 px-6 rounded-full transition-colors duration-200"
+                >
+                  {formatDate(day.date)}
+                </button>
+              ))}
+            </div>
+          )}
+
           {schedule.map((day) => {
-            const renderedSessions = new Map<string,Set<number>>();
+            const renderedSessions = new Map<string, Set<number>>();
             return (
-              <div key={day.date} className="mb-16">
-                <h2 className="text-3xl font-bold text-gray-900 mb-8 text-center">
+              <div key={day.date} id={day.date} className="mb-16">
+                <h2 className="text-3xl font-bold text-gray-900 my-8 text-center">
                   {formatDate(day.date)}
                 </h2>
                 <div
-                  className="grid gap-px bg-gray-200 border border-gray-200 rounded-lg overflow-hidden"
+                  className="hidden md:grid gap-px bg-gray-200 border border-gray-300 rounded-lg overflow-hidden"
                   style={{
                     gridTemplateColumns: `minmax(80px, 0.5fr) repeat(${day.rooms.length}, 1fr)`,
                   }}
                 >
                   {/* Header Row */}
-                  <div className="bg-gray-100 p-4 font-bold text-center">Time</div>
+                  <div className="bg-gray-100 p-4 font-bold text-center">
+                    Time
+                  </div>
                   {day.rooms.map((room) => (
                     <div
                       key={room.id}
@@ -140,55 +185,131 @@ const SchedulePage: React.FC<PageProps> = () => {
                         : null;
 
                     if (plenumSession) {
-                      const concurrent = renderedSessions.get(timeSlot.slotStart)?.size || 0
+                      const concurrent =
+                        renderedSessions.get(timeSlot.slotStart)?.size || 0;
                       return [
-                        <div key={`${timeSlot.slotStart}-time`} className="bg-white p-4 text-center font-semibold flex items-center justify-center">
+                        <div
+                          key={`${timeSlot.slotStart}-time`}
+                          className="bg-white p-4 text-center font-semibold flex items-center justify-center"
+                        >
                           {formatTime(timeSlot.slotStart)}
                         </div>,
-                        <div key={`${timeSlot.slotStart}-session`} className="bg-white p-1" style={{ gridColumn: `span ${day.rooms.length - concurrent}` }}>
-                          <SessionCard session={plenumSession} onClick={() => handleSessionClick(plenumSession)} />
+                        <div
+                          key={`${timeSlot.slotStart}-session`}
+                          className="bg-white p-1"
+                          style={{
+                            gridColumn: `span ${day.rooms.length - concurrent}`,
+                          }}
+                        >
+                          <SessionCard
+                            session={plenumSession}
+                            onClick={() => handleSessionClick(plenumSession)}
+                          />
                         </div>,
                       ];
                     }
 
                     const timeCell = (
-                      <div key={`${timeSlot.slotStart}-time`} className="bg-white p-4 text-center font-semibold flex items-center justify-center">
+                      <div
+                        key={`${timeSlot.slotStart}-time`}
+                        className="bg-white p-4 text-center font-semibold flex items-center justify-center"
+                      >
                         {formatTime(timeSlot.slotStart)}
                       </div>
                     );
 
                     const sessionCells = day.rooms.flatMap((room) => {
                       // This room already has a continued session for the timeslot
-                      if (renderedSessions.get(timeSlot.slotStart)?.has(room.id)) {
+                      if (
+                        renderedSessions.get(timeSlot.slotStart)?.has(room.id)
+                      ) {
                         return [];
                       }
 
                       // Nothing happens in the room at this time
-                      const sessionForRoom = timeSlot.rooms.find((r) => r.id === room.id)?.session;
+                      const sessionForRoom = timeSlot.rooms.find(
+                        (r) => r.id === room.id
+                      )?.session;
                       if (!sessionForRoom || !sessionForRoom.id) {
-                        return [<div key={`${timeSlot.slotStart}-${room.id}`} className="bg-white p-1" />];
+                        return [
+                          <div
+                            key={`${timeSlot.slotStart}-${room.id}`}
+                            className="bg-white p-1"
+                          />,
+                        ];
                       }
 
                       // A session is schedules for this timeslot
                       let rowSpan = 1;
                       const ends = new Date(sessionForRoom.endsAt);
-                      for (let i = timeSlotIndex + 1; i < day.timeSlots.length; i++) {
-                        const slotStart = new Date(day.timeSlots[i].rooms[0].session.startsAt);
+                      for (
+                        let i = timeSlotIndex + 1;
+                        i < day.timeSlots.length;
+                        i++
+                      ) {
+                        const slotStart = new Date(
+                          day.timeSlots[i].rooms[0].session.startsAt
+                        );
                         if (slotStart < ends) {
                           rowSpan++;
-                          if (!renderedSessions.has(day.timeSlots[i].slotStart)) {
-                            renderedSessions.set(day.timeSlots[i].slotStart, new Set());
+                          if (
+                            !renderedSessions.has(day.timeSlots[i].slotStart)
+                          ) {
+                            renderedSessions.set(
+                              day.timeSlots[i].slotStart,
+                              new Set()
+                            );
                           }
-                          renderedSessions.get(day.timeSlots[i].slotStart)?.add(room.id);
+                          renderedSessions
+                            .get(day.timeSlots[i].slotStart)
+                            ?.add(room.id);
                         } else {
                           break;
                         }
                       }
-                      return [<div key={`${timeSlot.slotStart}-${room.id}`} className="bg-white p-1" style={{ gridRow: `span ${rowSpan}` }}><SessionCard session={sessionForRoom} onClick={() => handleSessionClick(sessionForRoom)} /></div>];
+                      return [
+                        <div
+                          key={`${timeSlot.slotStart}-${room.id}`}
+                          className="bg-white p-1"
+                          style={{ gridRow: `span ${rowSpan}` }}
+                        >
+                          <SessionCard
+                            session={sessionForRoom}
+                            onClick={() => handleSessionClick(sessionForRoom)}
+                          />
+                        </div>,
+                      ];
                     });
 
                     return [timeCell, ...sessionCells];
                   })}
+                </div>
+                <div className="md:hidden">
+                  {day.timeSlots.map((timeSlot) => (
+                    <div key={timeSlot.slotStart} className="mb-8">
+                      <h3 className="text-xl font-semibold text-gray-800 mb-4 bg-gray-100 p-3 rounded-t-lg border-b border-gray-200">
+                        {formatTime(timeSlot.slotStart)}
+                      </h3>
+                      <div className="space-y-4">
+                        {timeSlot.rooms.map((room) => (
+                          <div
+                            key={room.id}
+                            className="bg-white p-1 rounded-lg shadow-sm border border-gray-300"
+                          >
+                            <div className="p-3">
+                              <p className="font-bold text-gray-600">
+                                {room.name}
+                              </p>
+                            </div>
+                            <SessionCard
+                              session={room.session}
+                              onClick={() => handleSessionClick(room.session)}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </div>
             );
@@ -203,7 +324,10 @@ const SchedulePage: React.FC<PageProps> = () => {
         />
       )}
       {selectedSpeaker && (
-        <SpeakerModal speaker={selectedSpeaker} onClose={() => setSelectedSpeaker(null)} />
+        <SpeakerModal
+          speaker={selectedSpeaker}
+          onClose={() => setSelectedSpeaker(null)}
+        />
       )}
     </Layout>
   );


### PR DESCRIPTION
This pull request introduces several improvements to the conference schedule page and its modal components, focusing on accessibility, user experience, and responsive design. The most significant changes add keyboard accessibility for closing modals, redesign the modal footers for better usability, and introduce a mobile-friendly schedule layout.

**Accessibility and UX improvements:**

- Added support for closing both `SessionModal` and `SpeakerModal` with the Escape key, improving accessibility for keyboard users. [[1]](diffhunk://#diff-e16c94cd6592c7f70aceb06529b76347a968a79dbec9b3a609f321b06f86298eR22-R53) [[2]](diffhunk://#diff-ddfa86446cc2f1ad5b4980e0cb3ae96a8b712168b65f56da2b46585e4d297377R9-R40)
- Redesigned modal footers: replaced the old close ("×") button with a full-width, clearly labeled button ("Back to Schedule" or "Back to Talk") and added a gradient overlay for visual separation. [[1]](diffhunk://#diff-e16c94cd6592c7f70aceb06529b76347a968a79dbec9b3a609f321b06f86298eL87-R116) [[2]](diffhunk://#diff-ddfa86446cc2f1ad5b4980e0cb3ae96a8b712168b65f56da2b46585e4d297377R78-R87)

**Responsive and visual enhancements:**

- Introduced a mobile-friendly schedule layout: on small screens, the schedule now displays as stacked cards per timeslot and room, improving readability and usability on mobile devices.
- Improved visual consistency by adjusting padding, border colors, and spacing across schedule cards and grid layouts. [[1]](diffhunk://#diff-ca2f6e0fdd964a5f7ff1ad7dacf917db1a22c773576d639959dfa5c3219652e4L19-R26) [[2]](diffhunk://#diff-ca2f6e0fdd964a5f7ff1ad7dacf917db1a22c773576d639959dfa5c3219652e4L31-R39) [[3]](diffhunk://#diff-ca2f6e0fdd964a5f7ff1ad7dacf917db1a22c773576d639959dfa5c3219652e4L102-R169)

**Navigation improvements:**

- Added day navigation buttons at the top of the schedule, allowing users to quickly jump to different days of the event.

Other changes include code formatting and minor refactoring for readability.

<img width="381" height="836" alt="Screenshot 2025-09-17 at 12 41 18" src="https://github.com/user-attachments/assets/002cd1cb-2687-47a8-84f5-72ff7c4df7b5" />
<img width="381" height="838" alt="Screenshot 2025-09-17 at 12 41 12" src="https://github.com/user-attachments/assets/7ec6c6c3-1f76-458e-a8af-46e46d57fead" />
<img width="387" height="842" alt="Screenshot 2025-09-17 at 12 40 58" src="https://github.com/user-attachments/assets/77e52826-9319-4783-9bf4-0ba7129e1738" />
<img width="390" height="841" alt="Screenshot 2025-09-17 at 12 40 52" src="https://github.com/user-attachments/assets/aa01b6ff-47c7-4704-b233-abc1dc60557d" />