### PR TITLE
fix: Schedule Modal Back Button Padding

### DIFF
--- a/src/components/session_modal.tsx
+++ b/src/components/session_modal.tsx
@@ -104,7 +104,7 @@ const SessionModal: React.FC<{
             )}
           </div>
 
-          <div className="px-8 py-4 sm:pb-6 text-center bg-white flex-shrink-0 relative">
+          <div className="p-4 pb-8 text-center bg-white flex-shrink-0 relative">
             <div className="absolute bottom-full left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent pointer-events-none"></div>
             <button
               onClick={onClose}

--- a/src/components/speaker_modal.tsx
+++ b/src/components/speaker_modal.tsx
@@ -75,7 +75,7 @@ const SpeakerModal: React.FC<{ speaker: Speaker; onClose: () => void }> = ({
               </div>
             )}
           </div>
-          <div className="px-8 py-4 sm:pb-6 text-center bg-white flex-shrink-0 relative">
+          <div className="p-4 pb-8 text-center bg-white flex-shrink-0 relative">
             <div className="absolute bottom-full left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent pointer-events-none"></div>
             <button
               onClick={onClose}


### PR DESCRIPTION
This pull request makes minor UI adjustments to the padding and spacing of the modal footer sections in both the `SessionModal` and `SpeakerModal` components to improve visual consistency.

- UI Consistency Improvements:
  * Updated padding and bottom spacing for the modal footer in `SessionModal` (`src/components/session_modal.tsx`).
  * Updated padding and bottom spacing for the modal footer in `SpeakerModal` (`src/components/speaker_modal.tsx`).