### PR TITLE
feat: Add Session Archive

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -23,6 +23,10 @@ const config: GatsbyConfig = {
         name: "Team",
         link: "/team",
       },
+      {
+        name: "Archive",
+        link: "/archive",
+      },
     ],
     team: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mdx-js/react": "^2.0.0",
         "@svgr/webpack": "^8.1.0",
         "autoprefixer": "^10.4.20",
+        "fuse.js": "^7.1.0",
         "gatsby": "^5.14.1",
         "gatsby-plugin-image": "^3.14.0",
         "gatsby-plugin-manifest": "^5.14.0",
@@ -9516,6 +9517,15 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gatsby": {
@@ -25829,6 +25839,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+    },
+    "fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ=="
     },
     "gatsby": {
       "version": "5.14.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@mdx-js/react": "^2.0.0",
     "@svgr/webpack": "^8.1.0",
     "autoprefixer": "^10.4.20",
+    "fuse.js": "^7.1.0",
     "gatsby": "^5.14.1",
     "gatsby-plugin-image": "^3.14.0",
     "gatsby-plugin-manifest": "^5.14.0",

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useRef, useEffect } from "react";
+
+interface DropdownProps {
+  options: { value: string; label: string }[];
+  selectedValue: string;
+  onSelect: (value: string) => void;
+}
+
+const Dropdown: React.FC<DropdownProps> = ({
+  options,
+  selectedValue,
+  onSelect,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleSelect = (value: string) => {
+    onSelect(value);
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="p-4 border border-gray-300 rounded-lg bg-white w-full flex justify-between items-center"
+        style={{ minWidth: "120px" }}
+      >
+        <span>
+          {options.find((opt) => opt.value === selectedValue)?.label ||
+            selectedValue}
+        </span>
+        <svg
+          className={`w-4 h-4 transition-transform duration-200 ${
+            isOpen ? "transform rotate-180" : ""
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M19 9l-7 7-7-7"
+          ></path>
+        </svg>
+      </button>
+      {isOpen && (
+        <div className="absolute z-10 mt-2 w-full bg-white border border-gray-300 rounded-lg shadow-lg">
+          <ul>
+            {options.map((option) => (
+              <li
+                key={option.value}
+                onClick={() => handleSelect(option.value)}
+                className="p-4 hover:bg-gray-100 cursor-pointer"
+              >
+                {option.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/components/session_modal.tsx
+++ b/src/components/session_modal.tsx
@@ -102,23 +102,6 @@ const SessionModal: React.FC<{
                 />
               </div>
             )}
-
-            {session.video && (
-              <div className="mt-6">
-                <h3 className="text-xl font-bold text-gray-800 mb-3">
-                  Recording
-                </h3>
-                <div className="aspect-w-16 aspect-h-9">
-                  <iframe
-                    src={session.video}
-                    title={session.title || session.name}
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    allowFullScreen
-                    className="w-full h-full rounded-lg"
-                  ></iframe>
-                </div>
-              </div>
-            )}
           </div>
 
           <div className="p-4 pb-8 text-center bg-white flex-shrink-0 relative flex justify-center gap-4">
@@ -129,15 +112,6 @@ const SessionModal: React.FC<{
             >
               Back to Schedule
             </button>
-            {session.slideDeck && (
-              <a
-                href={session.slideDeck}
-                rel="noopener noreferrer"
-                className="bg-background hover:bg-hover text-white font-semibold py-3 px-8 rounded-full text-lg transition-colors duration-200"
-              >
-                Presentation
-              </a>
-            )}
           </div>
         </div>
       </div>

--- a/src/components/speaker_modal.tsx
+++ b/src/components/speaker_modal.tsx
@@ -81,7 +81,7 @@ const SpeakerModal: React.FC<{ speaker: Speaker; onClose: () => void }> = ({
               onClick={onClose}
               className="bg-background hover:bg-hover text-white font-semibold py-3 px-8 rounded-full text-lg transition-colors duration-200"
             >
-              Back to Talk
+              Back
             </button>
           </div>
         </div>

--- a/src/hooks/use-sessionize.tsx
+++ b/src/hooks/use-sessionize.tsx
@@ -1,12 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 
-const SESSIONIZE_ID = 'ri9gml9f' // 'ri9gml9f'; // TEST ID: jl4ktls0
+export const MainSessionizeId = "ri9gml9f"; // 'ri9gml9f'; // TEST ID: jl4ktls0
 
 export interface SpeakerSession {
   id: number;
   name: string;
 }
-
 export interface Speaker {
   id: string;
   name: string;
@@ -19,7 +18,6 @@ export interface Speaker {
   isTopSpeaker: boolean;
   sessions: SpeakerSession[];
 }
-
 export interface Session {
   id: string;
   name: string;
@@ -39,85 +37,105 @@ export interface Session {
   video: string;
   rate: string;
 }
-
 export interface QuestionAnswer {
   id: number;
   answer: string;
 }
-
 export interface GridEntry {
   date: string;
   rooms: Room[];
   timeSlots: TimeSlot[];
 }
-
 export interface Room {
   id: number;
   name: string;
   sessions: Session[];
   session: Session;
 }
-
 export interface TimeSlot {
   slotStart: string;
   rooms: Room[];
 }
-
 export interface SessionList {
   sessions: Session[];
 }
-
-export const useSessionizeSpeakers = () => {
+export const useSessionizeSpeakers = (
+  sessionId: string = MainSessionizeId
+) => {
   const [speakers, setSpeakers] = useState<Speaker[]>([]);
 
   const fetchSpeakers = async () => {
-    const response = await fetch(`https://sessionize.com/api/v2/${SESSIONIZE_ID}/view/Speakers`);
+    const response = await fetch(
+      `https://sessionize.com/api/v2/${sessionId}/view/Speakers`
+    );
     const data: Speaker[] = await response.json();
-    setSpeakers(data.filter(speaker => speaker.profilePicture !== null));
+    setSpeakers(data.filter((speaker) => speaker.profilePicture !== null));
   };
 
   useEffect(() => {
-    fetchSpeakers();
-  }, []);
+    if (sessionId) {
+      fetchSpeakers();
+    }
+  }, [sessionId]);
 
   return { speakers };
 };
-
-export const useSessionizeSchedule = () => {
+export const useSessionizeSchedule = (
+  sessionId: string = MainSessionizeId
+) => {
   const [grid, setGrid] = useState<GridEntry[]>([]);
   const [speakers, setSpeakers] = useState<Speaker[]>([]);
   const [schedule, setSchedule] = useState<GridEntry[]>([]);
   const [sessions, setSessions] = useState<SessionList[]>([]);
 
   const fetchGrid = async () => {
-    const response = await fetch(`https://sessionize.com/api/v2/${SESSIONIZE_ID}/view/Grid`);
+    const response = await fetch(
+      `https://sessionize.com/api/v2/${sessionId}/view/Grid`
+    );
     const data = await response.json();
     setGrid(data);
   };
 
   const fetchSpeakers = async () => {
-    const response = await fetch(`https://sessionize.com/api/v2/${SESSIONIZE_ID}/view/Speakers`);
+    const response = await fetch(
+      `https://sessionize.com/api/v2/${sessionId}/view/Speakers`
+    );
     const data = await response.json();
     setSpeakers(data);
   };
 
   const fetchSessions = async () => {
-    const response = await fetch(`https://sessionize.com/api/v2/${SESSIONIZE_ID}/view/Sessions`);
+    const response = await fetch(
+      `https://sessionize.com/api/v2/${sessionId}/view/Sessions`
+    );
     const data = await response.json();
     setSessions(data);
   };
 
   useEffect(() => {
-    fetchGrid();
-  }, []);
+    if (sessionId) {
+      fetchGrid();
+    }
+  }, [sessionId]);
   useEffect(() => {
-    fetchSpeakers();
-  }, []);
+    if (sessionId) {
+      fetchSpeakers();
+    }
+  }, [sessionId]);
   useEffect(() => {
-    fetchSessions();
-  }, []);
+    if (sessionId) {
+      fetchSessions();
+    }
+  }, [sessionId]);
   useEffect(() => {
-    if (grid.length === 0 || speakers.length === 0 || sessions.length === 0) return;
+    if (
+      grid.length === 0 ||
+      speakers.length === 0 ||
+      sessions.length === 0
+    ) {
+      setSchedule([]);
+      return;
+    }
     const schedule = grid.map((entry) => {
       const timeSlots = entry.timeSlots.map((timeSlot) => {
         const rooms = timeSlot.rooms.map((room) => {
@@ -126,7 +144,9 @@ export const useSessionizeSchedule = () => {
           });
           room.session.speakers = sessionSpeakers.filter((s) => s !== undefined);
 
-          const session = sessions[0].sessions.find((s) => room.session.id === s.id);
+          const session = sessions[0].sessions.find(
+            (s) => room.session.id === s.id
+          );
           if (session !== undefined) {
             const slides = session.questionAnswers.find((q) => q.id === 99194);
             if (slides !== undefined) {

--- a/src/pages/archive.tsx
+++ b/src/pages/archive.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useMemo } from "react";
+import { type HeadFC, type PageProps } from "gatsby";
+import Layout from "../components/layout";
+import SEO from "../components/seo";
+import { useSessionizeSchedule, type Speaker } from "../hooks/use-sessionize";
+import Fuse from "fuse.js";
+import SpeakerModal from "../components/speaker_modal";
+
+import Dropdown from "../components/dropdown";
+
+const sessionizeEvents = {
+  "2025": { id: "ri9gml9f", name: "CND 2025 Aarhus", location: "Aarhus" },
+  "2024": { id: "cg322q6k", name: "KCD Denmark 2024", location: "Copenhagen" },
+};
+
+const ArchivePage: React.FC<PageProps> = () => {
+  const [selectedYear, setSelectedYear] = useState("2025");
+  const { schedule } = useSessionizeSchedule(sessionizeEvents[selectedYear].id);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedSpeaker, setSelectedSpeaker] = useState<Speaker | null>(null);
+
+  const sessions = useMemo(() => {
+    if (!schedule.length) return [];
+
+    return schedule
+      .flatMap((day) => day.timeSlots)
+      .flatMap((slot) => slot.rooms)
+      .map((room) => ({
+        ...room.session,
+        room: room.name,
+      }))
+      .filter(
+        (session) =>
+          !session.isServiceSession &&
+          session.speakers &&
+          session.speakers.length > 0
+      );
+  }, [schedule]);
+
+  const archivedSessions = useMemo(() => {
+    if (!sessions.length) return [];
+    const eventInfo = sessionizeEvents[selectedYear];
+    return sessions.map((session) => {
+      return {
+        ...session,
+        event: eventInfo.name,
+        year: selectedYear,
+        location: eventInfo.location,
+      };
+    });
+  }, [sessions, selectedYear]);
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(archivedSessions, {
+        keys: [
+          "title",
+          "description",
+          "speakers.fullName",
+          "event",
+          "year",
+          "location",
+        ],
+        threshold: 0.3,
+      }),
+    [archivedSessions]
+  );
+
+  const filteredSessions = useMemo(() => {
+    if (!searchQuery) {
+      return archivedSessions;
+    }
+    return fuse.search(searchQuery).map((result) => result.item);
+  }, [searchQuery, archivedSessions, fuse]);
+
+  const yearOptions = Object.keys(sessionizeEvents)
+    .sort((a, b) => parseInt(b) - parseInt(a))
+    .map((year) => ({
+      value: year,
+      label: year,
+    }));
+
+  return (
+    <Layout>
+      <section className="py-16 bg-white">
+        <div className="mx-auto max-w-6xl px-6">
+          <h2 className="text-4xl lg:text-5xl font-bold text-gray-900 mb-12 text-center">
+            Archive
+          </h2>
+          <div className="mb-8 max-w-lg mx-auto flex flex-col sm:flex-row gap-4">
+            <input
+              type="text"
+              placeholder="Search talks by title, speaker, description..."
+              className="w-full p-4 border border-gray-300 rounded-lg"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            <Dropdown
+              options={yearOptions}
+              selectedValue={selectedYear}
+              onSelect={setSelectedYear}
+            />
+          </div>
+          <div className="space-y-8">
+            {!archivedSessions.length ? (
+              <p className="text-center">Loading talks...</p>
+            ) : (
+              filteredSessions.map((session) => (
+                <div
+                  key={session.id}
+                  className="p-6 border border-gray-200 rounded-lg text-left"
+                >
+                  <h3 className="text-2xl font-bold">{session.title}</h3>
+                  {session.speakers && session.speakers.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-4 mt-3">
+                      {session.speakers.map((speaker) => (
+                        <div
+                          key={speaker.id}
+                          className="flex items-center gap-2 cursor-pointer"
+                          onClick={() => setSelectedSpeaker(speaker)}
+                        >
+                          <img
+                            src={speaker.profilePicture}
+                            alt={speaker.fullName}
+                            className="w-8 h-8 rounded-full object-cover"
+                          />
+                          <p className="text-md font-semibold">
+                            {speaker.fullName}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  <p className="mt-4 text-gray-700">{session.description}</p>
+                  <div className="mt-4 text-sm text-gray-600">
+                    <span>
+                      {new Date(session.startsAt).toLocaleString([], {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>{" "}
+                    | <span>{session.event}</span> | <span>{session.room}</span>
+                  </div>
+                  <div className="mt-6 flex gap-4">
+                    {session.video ? (
+                      <a
+                        href={session.video}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center text-white font-semibold py-3 px-6 rounded-full text-md transition-colors duration-200 bg-background hover:bg-hover"
+                      >
+                        Video
+                      </a>
+                    ) : (
+                      <button
+                        disabled
+                        className="inline-flex items-center justify-center text-gray-500 font-semibold py-2 px-6 rounded-full text-md transition-colors duration-200 bg-gray-200 cursor-not-allowed"
+                      >
+                        Video
+                      </button>
+                    )}
+                    {session.slideDeck ? (
+                      <a
+                        href={`https://docs.google.com/gview?url=${session.slideDeck}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center text-white font-semibold py-2 px-6 rounded-full text-md transition-colors duration-200 bg-background hover:bg-hover"
+                      >
+                        Slides
+                      </a>
+                    ) : (
+                      <button
+                        disabled
+                        className="inline-flex items-center justify-center text-gray-500 font-semibold py-2 px-6 rounded-full text-md transition-colors duration-200 bg-gray-200 cursor-not-allowed"
+                      >
+                        Slides
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </section>
+      {selectedSpeaker && (
+        <SpeakerModal
+          speaker={selectedSpeaker}
+          onClose={() => setSelectedSpeaker(null)}
+        />
+      )}
+    </Layout>
+  );
+};
+
+export default ArchivePage;
+
+export const Head: HeadFC = ({ location: { pathname } }) => (
+  <SEO pathname={pathname} />
+);


### PR DESCRIPTION
Currently, links to Slides and Videos are embedded in the Session Modal. This introduces additional overhead of finding and navigating to the session of interest, just to see if related assets are available.

Improve user experience by adding a fuzzy-searchable archive page for past event sessions, featuring links to session slides and videos.

<img width="1891" height="930" alt="Screenshot 2025-10-26 at 21 46 51" src="https://github.com/user-attachments/assets/70ab0c0b-610f-4855-83f5-3425ab97fdd9" />