### PR TITLE
feat: Annual Website Releases to CloudFlare

### DIFF
--- a/.github/CLOUDFLARE_SETUP.md
+++ b/.github/CLOUDFLARE_SETUP.md
@@ -1,0 +1,65 @@
+# Cloudflare Pages Setup for Release Deployments
+
+This document explains the Cloudflare configuration required for automated deployments to release-based subdomains (e.g., `2025.cloudnativedenmark.dk`, `feat-testing.cloudnativedenmark.dk`).
+
+## Overview
+
+Each release gets deployed to its own subdomain using Cloudflare Pages. This setup enables multiple concurrent versions of the site while maintaining a clean URL structure.
+
+## Prerequisites
+
+Before setting up deployments, ensure you have:
+
+- A Cloudflare account with the `cloudnativedenmark.dk` domain
+- GitHub repository access with Actions enabled
+
+## Configuration Steps
+
+### 1. GitHub Actions Configuration
+
+GitHub repository secrets must be configured first to enable automated deployments.
+
+#### Required Secrets
+
+Set up the following repository secrets in your GitHub repository (Settings → Secrets and variables → Actions -> Repository secrets):
+
+#### CLOUDFLARE_API_TOKEN
+
+1. Navigate to Cloudflare Dashboard → Go to... → Account API tokens
+2. Click "Create Token"
+3. Select "Custom token"
+4. Configure permissions:
+   - `Cloudflare Pages:Edit`
+5. Set Account Resources to "Include - All accounts"
+6. Click "Continue to summary" and create the token
+7. Add token as `CLOUDFLARE_API_TOKEN` GitHub repository secrets
+
+#### CLOUDFLARE_ACCOUNT_ID
+
+1. Navigate to Cloudflare Dashboard -> Go to... → Compute (Workers)
+2. Find Account Details and copy Account ID (format: `1234567890abcdef1234567890abcdef`)
+3. Add the ID as `CLOUDFLARE_ACCOUNT_ID` GitHub repository secrets
+
+### 2. Pages Project Creation
+
+Pages projects are automatically created by Wrangler during the first deployment. The naming convention is `cloudnative-denmark-<release-name>` (e.g., `cloudnative-denmark-2025`, `cloudnative-denmark-feat-testing`).
+
+### 3. Custom Domain Setup
+
+After the initial deployment to a new release project:
+
+1. Navigate to Cloudflare Dashboard → Workers & Pages → Pages
+2. Select your project (e.g., `cloudnative-denmark-2025`)
+3. Go to the Custom domains tab
+4. Click "Set up a custom domain"
+5. Enter the release-based subdomain: `2025.cloudnativedenmark.dk`
+6. Complete Cloudflare's domain verification process. This will create the DNS CNAME record like below:
+
+```
+
+Name: 2025
+Type: CNAME
+Content: cloudnative-denmark-2025.pages.dev
+Proxy status: Proxied (orange cloud enabled)
+TTL: Auto
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Deploy Release to CloudFlare
+
+on:
+  push:
+    branches:
+      - "release-*"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.ref_name }}"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Validate branch name
+        run: |
+          if [[ ! "${{ github.ref_name }}" =~ ^release- ]]; then
+            echo "❌ Error: This workflow can only run on branches starting with 'release-'"
+            echo "Current branch: ${{ github.ref_name }}"
+            echo "Expected format: release-*"
+            exit 1
+          fi
+          echo "✅ Branch name is valid: ${{ github.ref_name }}"
+
+      - name: Extract release name from branch
+        id: extract-release
+        run: |
+          BRANCH_NAME="${{ github.ref_name }}"
+          RELEASE_NAME=$(echo "$BRANCH_NAME" | sed 's/^release-//')
+          if [ -z "$RELEASE_NAME" ]; then
+            echo "Error: Invalid branch name format. Expected 'release-<name>', got '$BRANCH_NAME'"
+            exit 1
+          fi
+          # Validate URL-safe characters (alphanumeric, hyphens, underscores)
+          if [[ ! "$RELEASE_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "Error: Release name contains invalid characters. Only alphanumeric, hyphens, and underscores are allowed."
+            echo "Release name: '$RELEASE_NAME'"
+            exit 1
+          fi
+          echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
+          echo "subdomain=${RELEASE_NAME}.cloudnativedenmark.dk" >> $GITHUB_OUTPUT
+          echo "Deploying to: ${RELEASE_NAME}.cloudnativedenmark.dk"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Yarn Berry
+        run: corepack prepare yarn@4.9.1 --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run TypeScript type checking
+        run: yarn typecheck
+
+      - name: Run ESLint
+        run: yarn lint
+
+      - name: Check code formatting
+        run: yarn format
+
+      - name: Run tests
+        run: yarn test
+
+      - name: Build website
+        run: yarn build
+
+      - name: Create Pages project (if needed)
+        continue-on-error: true
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create cloudnative-denmark-${{ steps.extract-release.outputs.release_name }} --production-branch=${{ github.ref_name }}
+
+      - name: Deploy to CloudFlare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy dist --project-name=cloudnative-denmark-${{ steps.extract-release.outputs.release_name }}


### PR DESCRIPTION
Add automated deployment of release branches to Cloudflare Pages, with each release deployed to its own subdomain, and a guide on how to hide them behind well-known, custom subdomains.