### PR TITLE
feat(sponsors): Move lanyard logo to paid addon

### DIFF
--- a/src/pages/become-a-sponsor.tsx
+++ b/src/pages/become-a-sponsor.tsx
@@ -56,9 +56,11 @@ const sponsorTiers: SponsorTier[] = [
       "30% discount for guests (10 tickets)**",
       "Lead scanner app",
       "Branding on swag and marketing material",
-      "Logo on lanyard",
     ],
-    addons: ["20,000 DKK: Promotion at the after party"],
+    addons: [
+      "20,000 DKK: Promotion at the after party",
+      "20,000 DKK: Logo on lanyard",
+    ],
     availability: "Limited to 2 sponsorships or 1 sponsorship with 300,000 DKK",
   },
   {
@@ -74,8 +76,8 @@ const sponsorTiers: SponsorTier[] = [
       "30% discount for guests (10 tickets)**",
       "Lead scanner app",
       "Branding on swag and marketing material",
-      "Logo on lanyard",
     ],
+    addons: ["20,000 DKK: Logo on lanyard"],
     availability: "Limited to 4 sponsorships",
   },
   {
@@ -90,8 +92,8 @@ const sponsorTiers: SponsorTier[] = [
       "30% discount for guests (4 tickets)**",
       "Lead scanner app",
       "Branding on marketing material",
-      "Logo on lanyard",
     ],
+    addons: ["20,000 DKK: Logo on lanyard"],
     availability: "Limited to 5 sponsorships",
   },
   {
@@ -104,7 +106,6 @@ const sponsorTiers: SponsorTier[] = [
       "5 tickets",
       "Keynote mention",
       "Branding in common areas and logo on website",
-      "Logo on lanyard",
     ],
   },
 ]


### PR DESCRIPTION
Lanyard logo is now a 20,000 DKK addon for Platinum, Gold, and Bronze tiers instead of an included benefit. Removed from Community tier as it's not available for that tier.