### PR TITLE
ci: Add per-PR Cloudflare Pages preview environments

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,113 @@
+# Deploy per-PR preview environments to Cloudflare Pages.
+# Gated by the "preview-enabled" label; posts the preview URL as a PR comment.
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened, closed]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.action != 'unlabeled' &&
+      contains(github.event.pull_request.labels.*.name, 'preview-enabled')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Yarn Berry
+        run: corepack prepare yarn@4.9.1 --activate
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build website
+        run: yarn build
+
+      - name: Create Pages project (if needed)
+        continue-on-error: true
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create cloudnative-denmark-preview --production-branch=main
+
+      - name: Deploy preview to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy dist --project-name=cloudnative-denmark-preview --branch=pr-${{ github.event.pull_request.number }}
+
+      - name: Comment preview URL
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: preview
+          message: |
+            ### 🚀 Preview environment ready
+
+            | | |
+            |--|--|
+            | **Preview URL** | ${{ steps.deploy.outputs.pages-deployment-alias-url }} |
+            | **This build** | ${{ steps.deploy.outputs.deployment-url }} |
+            | **Commit** | `${{ github.event.pull_request.head.sha }}` |
+
+            Updates on every push while the `preview-enabled` label is set.
+            Removed automatically when the label is removed or the PR is closed.
+
+  teardown:
+    if: >-
+      github.event.action == 'closed' ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'preview-enabled')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Delete preview deployments
+        continue-on-error: true
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: cloudnative-denmark-preview
+          BRANCH: pr-${{ github.event.pull_request.number }}
+        run: |
+          api="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${PROJECT}/deployments"
+          ids=$(curl -s -H "Authorization: Bearer ${CF_API_TOKEN}" "${api}?per_page=100" \
+            | jq -r --arg b "${BRANCH}" '.result[]? | select(.deployment_trigger.metadata.branch == $b) | .id')
+          for id in ${ids}; do
+            echo "Deleting deployment ${id}"
+            curl -s -X DELETE -H "Authorization: Bearer ${CF_API_TOKEN}" "${api}/${id}?force=true" >/dev/null
+          done
+
+      - name: Remove preview comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: preview
+          message: |
+            🧹 Preview environment for this PR has been torn down.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ The site is automatically deployed to GitHub Pages on every push to the main bra
 - **Production**: `https://cloudnativedenmark.dk`
 - **GitHub Pages**: `https://cloudnativedenmark.github.io/cloudnativedenmark.dk`
 
+### Preview Environments
+
+Per-PR preview deployments to Cloudflare Pages, gated by a label (workflow: `.github/workflows/preview.yaml`).
+
+1. Add the `preview-enabled` label to a PR (only users with write/triage access can apply labels).
+2. The **PR Preview** workflow builds the site and deploys it to the `cloudnative-denmark-preview` Cloudflare Pages project under a per-PR alias.
+3. A bot comment posts the preview URL — `https://pr-<number>.cloudnative-denmark-preview.pages.dev` — and redeploys on every push while the label is set.
+4. The deployment is deleted automatically when the label is removed or the PR is closed/merged.
+
+Requires repo secrets `CLOUDFLARE_API_TOKEN` (Pages:Edit scope) and `CLOUDFLARE_ACCOUNT_ID`.
+
 ## 🤝 Contributing
 
 We welcome contributions! Please read our [Contributing Guide](./CONTRIBUTING.md) for details on:


### PR DESCRIPTION
## Summary
- Add a **PR Preview** GitHub Actions workflow that deploys the built site to a dedicated Cloudflare Pages project (`cloudnative-denmark-preview`) when a PR has the `preview-enabled` label.
- The workflow posts a sticky PR comment with the preview URL and redeploys on every push while labeled.
- Preview is torn down automatically when the label is removed or the PR is closed/merged.
- Document the preview workflow in the README.

This extracts the preview-environment work out of #106, which bundled it together with an unrelated Schedule nav feature.

## How to test the preview
1. Add the `preview-enabled` label to this PR.
2. Wait for the **PR Preview** workflow to finish; a comment with the preview URL will appear.
3. Open the URL and verify the site.
4. Remove the label (or close the PR) and confirm the teardown job runs.

Requires repo secrets `CLOUDFLARE_API_TOKEN` (Pages:Edit scope) and `CLOUDFLARE_ACCOUNT_ID`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8Yxm1di3dRxmkXBo6VSdy)_