### PR TITLE
[Proposal] feat: Sponsor info & FAQ page (unlinked)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Team from "./pages/team"
 import Venue from "./pages/venue"
 import VenuePlan from "./pages/venue-plan"
 import BecomeASponsor from "./pages/become-a-sponsor"
+import SponsorInfo from "./pages/sponsor-info"
 import NotFound from "./pages/404"
 
 function App() {
@@ -27,6 +28,8 @@ function App() {
         <Route path="venue" element={<Venue />} />
         <Route path="venue-plan" element={<VenuePlan />} />
         <Route path="become-a-sponsor" element={<BecomeASponsor />} />
+        {/* Not in nav — link directly to confirmed/prospective sponsors */}
+        <Route path="sponsor-info" element={<SponsorInfo />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>

--- a/src/pages/sponsor-info.tsx
+++ b/src/pages/sponsor-info.tsx
@@ -1,0 +1,153 @@
+import React from "react"
+import { useLocation } from "react-router-dom"
+import SEOHead from "../components/seo-head"
+import PageHeader from "../components/layout/page-header"
+import Section from "../components/ui/section"
+
+interface FAQEntry {
+  question: string
+  answer: React.ReactNode
+}
+
+interface FAQGroup {
+  title: string
+  entries: FAQEntry[]
+}
+
+const faqGroups: FAQGroup[] = [
+  {
+    title: "Booth & on-site logistics",
+    entries: [
+      {
+        question: "What's included with our booth?",
+        answer:
+          "Booth space includes standard furniture (table, chairs, power). Booth size scales with your tier — Extra Large for Platinum, Large for Gold, Regular for Bronze. If you need anything beyond standard furniture (screens, extra power, custom builds), let us know and we'll confirm what Scandic can provide.",
+      },
+      {
+        question: "Can we rent a screen or get roll-ups printed on site?",
+        answer:
+          "We're still confirming exact options and pricing with the venue for screen rental and on-site printing. If you need either, email us and we'll get you a straight answer as soon as we have one — don't wait until the week of the event.",
+      },
+      {
+        question: "When can we set up, and when do we need to be packed down?",
+        answer:
+          "Exact setup/teardown windows will be sent to confirmed sponsors closer to the event (November 19–20, 2026, Scandic Copenhagen). If you have travel or shipping constraints that need an earlier answer, reach out and we'll prioritize it.",
+      },
+    ],
+  },
+  {
+    title: "Tickets & guests",
+    entries: [
+      {
+        question: "How many tickets come with our tier?",
+        answer:
+          "Platinum: 6 tickets. Gold: 4 tickets. Bronze: 2 tickets. Community: 5 tickets. All paid tiers also come with a discount code for additional guest tickets, subject to general ticket availability.",
+      },
+      {
+        question: "Do we get access to attendee leads?",
+        answer:
+          "Platinum, Gold, and Bronze sponsors get access to the lead scanner app for badge scanning at your booth.",
+      },
+    ],
+  },
+  {
+    title: "Branding & marketing",
+    entries: [
+      {
+        question: "Where does our logo appear?",
+        answer:
+          "On the sponsors section of cloudnativedenmark.dk, in tier order, plus marketing material and swag as described in your tier. Send us a high-resolution SVG (dark-on-light works best against our site background) and we'll get it live — usually within a day.",
+      },
+      {
+        question: "Can we add a keynote mention or stage time?",
+        answer:
+          "Platinum sponsors get a 15-minute keynote presentation slot; Gold gets 2 minutes of keynote presence; Bronze and Community get a keynote mention. These are coordinated directly with the organizing team ahead of the schedule going out.",
+      },
+    ],
+  },
+  {
+    title: "Getting in touch",
+    entries: [
+      {
+        question: "Who do we contact with questions that aren't covered here?",
+        answer: (
+          <>
+            Email{" "}
+            <a
+              href="mailto:sponsor@cloudnativedenmark.dk"
+              className="text-cnd-red underline decoration-2 underline-offset-4 hover:text-cnd-coral"
+            >
+              sponsor@cloudnativedenmark.dk
+            </a>{" "}
+            and we'll get back to you directly rather than leave you guessing.
+          </>
+        ),
+      },
+    ],
+  },
+]
+
+const SponsorInfoPage: React.FC = () => {
+  const location = useLocation()
+
+  return (
+    <>
+      <SEOHead title="Sponsor Info & FAQ" pathname={location.pathname} />
+      <PageHeader
+        eyebrow="FOR SPONSORS"
+        title="Sponsor info & FAQ."
+        description="Answers to the questions sponsors ask us most. This page isn't in the site navigation — it's meant to be linked directly to confirmed and prospective sponsors."
+        variant="dark"
+        size="medium"
+      />
+      <Section className="bg-cnd-bone py-16">
+        <div className="mx-auto max-w-3xl space-y-12">
+          {faqGroups.map((group) => (
+            <div key={group.title}>
+              <h2
+                className="display text-cnd-midnight"
+                style={{ fontSize: 24, letterSpacing: "-0.02em" }}
+              >
+                {group.title}
+              </h2>
+              <div className="mt-4 space-y-3">
+                {group.entries.map((entry) => (
+                  <details
+                    key={entry.question}
+                    className="group rounded-xl border-2 border-cnd-fog/40 bg-white px-5 py-4 open:border-cnd-electric/70"
+                  >
+                    <summary className="cursor-pointer list-none font-semibold text-cnd-midnight marker:content-none">
+                      <span className="flex items-center justify-between gap-4">
+                        {entry.question}
+                        <span
+                          aria-hidden="true"
+                          className="shrink-0 text-cnd-electric transition-transform group-open:rotate-45"
+                          style={{ fontSize: 20, lineHeight: 1 }}
+                        >
+                          +
+                        </span>
+                      </span>
+                    </summary>
+                    <div
+                      className="mt-3 text-cnd-slate"
+                      style={{ fontSize: 15, lineHeight: 1.65 }}
+                    >
+                      {entry.answer}
+                    </div>
+                  </details>
+                ))}
+              </div>
+            </div>
+          ))}
+
+          <p className="text-center text-sm italic text-cnd-ash">
+            This is a first pass covering the questions we've heard most
+            often — if something's missing, tell us and we'll add it.
+          </p>
+        </div>
+      </Section>
+    </>
+  )
+}
+
+export default SponsorInfoPage

--- a/src/pages/sponsor-info.tsx
+++ b/src/pages/sponsor-info.tsx
@@ -20,18 +20,72 @@ const faqGroups: FAQGroup[] = [
     entries: [
       {
         question: "What's included with our booth?",
-        answer:
-          "Booth space includes standard furniture (table, chairs, power). Booth size scales with your tier — Extra Large for Platinum, Large for Gold, Regular for Bronze. If you need anything beyond standard furniture (screens, extra power, custom builds), let us know and we'll confirm what Scandic can provide.",
+        answer: (
+          <>
+            <p>Booth area sizes depend on your sponsorship tier:</p>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>
+                <strong>Platinum</strong>: 5x3 meters
+              </li>
+              <li>
+                <strong>Gold</strong>: 4x2 meters
+              </li>
+              <li>
+                <strong>Bronze</strong>: 3x2 meters
+              </li>
+            </ul>
+            <p className="mt-2">
+              Each booth area is provided with a standing-height table and power
+              outlets. All other equipment, displays, roll-ups, or additional
+              booth materials are the sponsor's own responsibility.
+            </p>
+          </>
+        ),
       },
       {
         question: "Can we rent a screen or get roll-ups printed on site?",
         answer:
-          "We're still confirming exact options and pricing with the venue for screen rental and on-site printing. If you need either, email us and we'll get you a straight answer as soon as we have one — don't wait until the week of the event.",
+          "We will share the delivery address for shipping goods to Scandic Copenhagen and rental options for extra equipment like TV screens or additional AV as soon as the venue finalizes them.",
+      },
+      {
+        question: "Is there a hotel booking discount code?",
+        answer: (
+          <>
+            <p>
+              Yes. We have arranged a booking code for discounted rooms at
+              Scandic Copenhagen. This code is sent by email to confirmed
+              sponsors.
+            </p>
+            <p className="mt-2">
+              If you did not receive your code or need it resent, please email{" "}
+              <a
+                href="mailto:sponsor@cloudnativedenmark.dk"
+                className="text-cnd-red underline decoration-2 underline-offset-4 hover:text-cnd-coral"
+              >
+                sponsor@cloudnativedenmark.dk
+              </a>
+              .
+            </p>
+            <p className="mt-2">
+              The booking code is valid for stays from November 18 to November
+              20, 2026. If any of your team members wish to stay outside these
+              dates, remove the code to book those additional nights separately,
+              then email{" "}
+              <a
+                href="mailto:copenhagen@scandichotels.com"
+                className="text-cnd-red underline decoration-2 underline-offset-4 hover:text-cnd-coral"
+              >
+                copenhagen@scandichotels.com
+              </a>{" "}
+              to request staying in the same room.
+            </p>
+          </>
+        ),
       },
       {
         question: "When can we set up, and when do we need to be packed down?",
         answer:
-          "Exact setup/teardown windows will be sent to confirmed sponsors closer to the event (November 19–20, 2026, Scandic Copenhagen). If you have travel or shipping constraints that need an earlier answer, reach out and we'll prioritize it.",
+          "We will send exact setup and teardown windows closer to the event. The conference runs November 19–20, 2026 at Scandic Copenhagen. If you have travel or shipping constraints that require an earlier answer, let us know and we will prioritize it.",
       },
     ],
   },
@@ -40,13 +94,69 @@ const faqGroups: FAQGroup[] = [
     entries: [
       {
         question: "How many tickets come with our tier?",
-        answer:
-          "Platinum: 6 tickets. Gold: 4 tickets. Bronze: 2 tickets. Community: 5 tickets. All paid tiers also come with a discount code for additional guest tickets, subject to general ticket availability.",
+        answer: (
+          <>
+            <p>Ticket allocations and guest discounts by tier:</p>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>
+                <strong>Platinum</strong>: 6 complimentary tickets + 10 tickets
+                at a 30% discount
+              </li>
+              <li>
+                <strong>Gold</strong>: 4 complimentary tickets + 10 tickets at a
+                30% discount
+              </li>
+              <li>
+                <strong>Bronze</strong>: 2 complimentary tickets + 4 tickets at
+                a 30% discount
+              </li>
+              <li>
+                <strong>Community</strong>: 5 complimentary tickets
+              </li>
+            </ul>
+            <p className="mt-2 text-sm italic">
+              Important: Ticket registrations (including sponsor codes) are
+              subject to general ticket availability. We recommend claiming and
+              registering your tickets as soon as possible to secure your seats.
+            </p>
+          </>
+        ),
       },
       {
         question: "Do we get access to attendee leads?",
         answer:
-          "Platinum, Gold, and Bronze sponsors get access to the lead scanner app for badge scanning at your booth.",
+          "Yes. Platinum, Gold, and Bronze sponsors get access to the TicketButler lead scanner. This is a standard mobile application you install on your own devices, accompanied by an event code for badge scanning. We will share the setup details closer to the event.",
+      },
+    ],
+  },
+  {
+    title: "Audience insights",
+    entries: [
+      {
+        question: "What is the attendee profile and size?",
+        answer:
+          "Last year, 477 active attendees represented 180 unique companies, including major Danish and international corporate enterprises.",
+      },
+      {
+        question: "What roles and job titles are represented?",
+        answer: (
+          <>
+            <p>The audience consists of practitioners and leaders:</p>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>
+                <strong>Core Engineering (58%+)</strong>: Practitioners holding
+                roles like Platform Engineer, Software Engineer, and DevOps
+                Engineer. Perfect for showcasing infrastructure tools, developer
+                platforms, or recruiting talent.
+              </li>
+              <li>
+                <strong>Technical Leadership (13% approx.)</strong>:
+                Decision-makers including CTOs, Directors, Team Leads, and
+                Product Managers.
+              </li>
+            </ul>
+          </>
+        ),
       },
     ],
   },
@@ -56,12 +166,38 @@ const faqGroups: FAQGroup[] = [
       {
         question: "Where does our logo appear?",
         answer:
-          "On the sponsors section of cloudnativedenmark.dk, in tier order, plus marketing material and swag as described in your tier. Send us a high-resolution SVG (dark-on-light works best against our site background) and we'll get it live — usually within a day.",
+          "On the sponsors section of cloudnativedenmark.dk in tier order, as well as on marketing material and swag described in your package. Send us a high-resolution SVG (dark-on-light works best) and we will publish it live, usually within a day.",
       },
       {
         question: "Can we add a keynote mention or stage time?",
-        answer:
-          "Platinum sponsors get a 15-minute keynote presentation slot; Gold gets 2 minutes of keynote presence; Bronze and Community get a keynote mention. These are coordinated directly with the organizing team ahead of the schedule going out.",
+        answer: (
+          <>
+            <p>
+              Stage presence and keynote presentation options depend on your
+              tier:
+            </p>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>
+                <strong>Platinum</strong>: A 15-minute technical keynote
+                presentation. This must be a strictly technical presentation,
+                not a product pitch.
+              </li>
+              <li>
+                <strong>Gold</strong>: A 2-minute stage key pitch to introduce
+                your company or message to the full audience (you are free to
+                present anything you'd like).
+              </li>
+              <li>
+                <strong>Bronze &amp; Community</strong>: Keynote mention only
+                (no active stage time).
+              </li>
+            </ul>
+            <p className="mt-2">
+              We coordinate these slots directly with your team before
+              publishing the schedule.
+            </p>
+          </>
+        ),
       },
     ],
   },

--- a/src/pages/sponsor-info.tsx
+++ b/src/pages/sponsor-info.tsx
@@ -141,8 +141,8 @@ const SponsorInfoPage: React.FC = () => {
           ))}
 
           <p className="text-center text-sm italic text-cnd-ash">
-            This is a first pass covering the questions we've heard most
-            often — if something's missing, tell us and we'll add it.
+            This is a first pass covering the questions we've heard most often —
+            if something's missing, tell us and we'll add it.
           </p>
         </div>
       </Section>


### PR DESCRIPTION
## Why
This came up independently three separate times and never got built:
- Jinhong, 2026-06-25: relaying a sponsor rep's feedback — "FAQ page on website for sponsors ... maybe Alek can put it on the website?" ([permalink](https://cloud-native-denmark.slack.com/archives/C09LJLSDYSY/p1782386100433949))
- Thor, 2026-06-19 and 2026-06-30: proposed it twice, explicitly **not** in the nav — "possible Alek could create a page (not listed in the navigation of the site)" / "I do not think it should be in the navigation" ([permalink 1](https://cloud-native-denmark.slack.com/archives/C09LJLSDYSY/p1781850142575399), [permalink 2](https://cloud-native-denmark.slack.com/archives/C09LJLSDYSY/p1782803971551419))
- Alek, 2026-06-29: "remember we spoke about an expanded Sponsors Page - or did I hallucinate this?" ([permalink](https://cloud-native-denmark.slack.com/archives/C09LJLSDYSY/p1782765215261109))

Confirmed via `grep -ri faq src/` and `git log --all -i --grep=faq` that no FAQ/sponsor-info page or route has ever existed in this repo.

## What
- New route `/sponsor-info` (`src/pages/sponsor-info.tsx`), **deliberately not added to any nav** per Thor's explicit ask — meant to be linked directly to sponsors rather than surfaced publicly.
- Accordion-style FAQ grouped into Booth & logistics / Tickets & guests / Branding & marketing / Getting in touch, built from facts already established elsewhere on the site (tier ticket counts, booth sizes, keynote slots, sponsor email) so nothing here contradicts `become-a-sponsor.tsx`.

## ⚠️ This is a proposal, not final copy
Thor mentioned a shared doc with the real FAQ content he and Søren were compiling — that doc wasn't reachable from this automated run, so the copy here is a first-pass draft covering the questions that came up most in Slack, written to be accurate but generic (e.g. screen rental is phrased as "still confirming," not promised). Treat this as a scaffold to edit against the real content, not something to merge as-is.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test`
- [x] Verified in a local dev server: page renders correctly at `/sponsor-info`, accordion open/close works, confirmed the route does **not** appear in header/footer nav

---
_Generated by [Claude Code](https://claude.ai/code/session_018Rzf2V6g7jX4mvuJ18UEDU)_