### PR TITLE
[Proposal] feat(footer): Sponsor thank-you + 2025 event link

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -47,6 +47,17 @@ const Footer = () => {
               A community-driven cloud native conference, organized by
               practitioners for practitioners.
             </p>
+            <p className="mt-4 max-w-sm text-sm text-cnd-fog">
+              Thank you to our sponsors for making CND/2026 possible.
+            </p>
+            <p className="mt-2 text-sm text-cnd-fog">
+              <ExternalLink
+                href="https://2025.cloudnativedenmark.dk/"
+                className="font-semibold text-white underline decoration-cnd-coral decoration-2 underline-offset-4 hover:text-cnd-coral"
+              >
+                See last year's event (CND/2025) →
+              </ExternalLink>
+            </p>
           </div>
 
           <nav>


### PR DESCRIPTION
## Why
Your own footer plan, 2025-12-22: "I think it'd be nice with a small footer... Maybe thank you to sponsors, short about CND, link to 2025 page, etc." then "I'll do them myself tho." ([permalink](https://cloud-native-denmark.slack.com/archives/C09LJLSDYSY/p1766399396677019))

The footer that shipped (`src/components/footer.tsx`) has the "about CND" blurb, contact info, and legal links — but never got the sponsor thank-you or the 2025 link, the two items still missing from that list.

## What
- A short "Thank you to our sponsors for making CND/2026 possible" line.
- A link to the 2025 archive site, using the same URL and link styling already established in `last-year-event-section.tsx` / `convince-your-boss.tsx`.

Both added to the existing intro column of the footer — no new sections, no layout changes elsewhere.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn format`
- [x] `yarn test`
- [x] Verified in a local dev server: renders correctly, link resolves to `https://2025.cloudnativedenmark.dk/`

---
_Generated by [Claude Code](https://claude.ai/code/session_018Rzf2V6g7jX4mvuJ18UEDU)_