### PR TITLE
Fix session redering

### DIFF
--- a/src/components/__tests__/session-modal.test.tsx
+++ b/src/components/__tests__/session-modal.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react"
+import SessionModal from "../session_modal"
+import { type Session } from "../../hooks/use-sessionize"
+
+const session: Session = {
+  id: "session-1",
+  name: "A regular talk",
+  title: "A regular talk",
+  description: "",
+  startsAt: "2026-11-19T09:00:00Z",
+  endsAt: "2026-11-19T09:35:00Z",
+  isServiceSession: false,
+  isPlenumSession: false,
+  speakers: [],
+  roomId: 1,
+  room: "Main stage",
+  categories: [],
+  questionAnswers: [],
+  recordingUrl: "",
+  slideDeck: "",
+  video: "",
+  rate: "",
+}
+
+const renderSessionModal = (description: string | null) =>
+  render(
+    <SessionModal
+      session={{ ...session, description }}
+      onClose={() => {}}
+      onSpeakerClick={() => {}}
+    />
+  )
+
+describe("SessionModal description", () => {
+  it("renders CRLF-separated descriptions as two paragraphs", () => {
+    renderSessionModal("First paragraph.\r\n\r\nSecond paragraph.")
+
+    expect(document.body.querySelectorAll("p")).toHaveLength(2)
+  })
+
+  it("renders a dash list with the correct number of items", () => {
+    renderSessionModal("- First item\n- Second item\n- Third item")
+
+    const list = document.body.querySelector("ul")
+    expect(list).not.toBeNull()
+    expect(list?.querySelectorAll("li")).toHaveLength(3)
+  })
+
+  it("does not create an executable script element from a description", () => {
+    const { container } = renderSessionModal("<script>alert(1)</script>")
+
+    expect(container.querySelector("script")).toBeNull()
+    expect(document.body.querySelector("script")).toBeNull()
+  })
+
+  it("does not render a Description heading for a null description", () => {
+    renderSessionModal(null)
+
+    expect(screen.queryByText("Description")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/session_modal.tsx
+++ b/src/components/session_modal.tsx
@@ -5,6 +5,7 @@ import {
   formatTimeDetailed,
   calculateSessionDuration,
 } from "../utils/time-formatting"
+import { formatPlainTextToHtml } from "../utils/text-formatting"
 import { deduceSessionType, getSessionTags } from "../utils/session-type"
 import SpeakerList from "./speaker-list"
 import SessionTypeBadge from "./session-type-badge"
@@ -24,6 +25,7 @@ const SessionModal: React.FC<{
     speakers: session.speakers,
   })
   const tags = getSessionTags(session.categories)
+  const formattedDescription = formatPlainTextToHtml(session.description)
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -103,14 +105,14 @@ const SessionModal: React.FC<{
               </div>
             )}
 
-            {session.description && (
+            {formattedDescription && (
               <div>
                 <h3 className="text-xl font-bold text-gray-800 mb-3">
                   Description
                 </h3>
                 <div
-                  className="text-gray-700 space-y-4"
-                  dangerouslySetInnerHTML={{ __html: session.description }}
+                  className="text-gray-700 space-y-4 leading-relaxed [&_ul]:list-disc [&_ul]:pl-5 [&_li+li]:mt-1"
+                  dangerouslySetInnerHTML={{ __html: formattedDescription }}
                 />
               </div>
             )}

--- a/src/components/speaker_modal.tsx
+++ b/src/components/speaker_modal.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom"
 import { type Speaker } from "../hooks/use-sessionize"
 import Button from "./ui/button"
 import SessionTypeBadge from "./session-type-badge"
+import { formatPlainTextToHtml } from "../utils/text-formatting"
 import { features } from "../config/features"
 
 const SpeakerModal: React.FC<{
@@ -33,6 +34,7 @@ const SpeakerModal: React.FC<{
 
   const isSessionInteractive =
     Boolean(onSessionClick) || features.scheduleAndSpeakers
+  const formattedBio = formatPlainTextToHtml(speaker.bio)
 
   return createPortal(
     <>
@@ -64,12 +66,12 @@ const SpeakerModal: React.FC<{
               </div>
             </div>
 
-            {speaker.bio && (
+            {formattedBio && (
               <div className="mb-6">
                 <h3 className="text-xl font-bold text-gray-800 mb-3">About</h3>
                 <div
-                  className="text-gray-700 space-y-4"
-                  dangerouslySetInnerHTML={{ __html: speaker.bio }}
+                  className="text-gray-700 space-y-4 leading-relaxed [&_ul]:list-disc [&_ul]:pl-5 [&_li+li]:mt-1"
+                  dangerouslySetInnerHTML={{ __html: formattedBio }}
                 />
               </div>
             )}

--- a/src/hooks/use-sessionize.tsx
+++ b/src/hooks/use-sessionize.tsx
@@ -20,7 +20,7 @@ export interface Speaker {
   firstName: string
   lastName: string
   fullName: string
-  bio: string
+  bio: string | null
   tagLine: string
   profilePicture: string | null
   isTopSpeaker: boolean
@@ -30,7 +30,7 @@ export interface Session {
   id: string
   name: string
   title: string
-  description: string
+  description: string | null
   startsAt: string
   endsAt: string
   isServiceSession: boolean

--- a/src/utils/__tests__/text-formatting.test.ts
+++ b/src/utils/__tests__/text-formatting.test.ts
@@ -1,0 +1,100 @@
+import { formatPlainTextToHtml } from "../text-formatting"
+
+describe("formatPlainTextToHtml", () => {
+  it("returns an empty string for null, undefined, empty, and whitespace-only input", () => {
+    expect(formatPlainTextToHtml(null)).toBe("")
+    expect(formatPlainTextToHtml(undefined)).toBe("")
+    expect(formatPlainTextToHtml("")).toBe("")
+    expect(formatPlainTextToHtml(" \r\n  ")).toBe("")
+  })
+
+  it("formats a single paragraph", () => {
+    expect(formatPlainTextToHtml("A single paragraph.")).toBe(
+      "<p>A single paragraph.</p>"
+    )
+  })
+
+  it("formats paragraphs separated by CRLF blank lines", () => {
+    expect(
+      formatPlainTextToHtml("First paragraph.\r\n\r\nSecond paragraph.")
+    ).toBe("<p>First paragraph.</p><p>Second paragraph.</p>")
+  })
+
+  it("collapses three or more newlines to one paragraph break", () => {
+    expect(
+      formatPlainTextToHtml("First paragraph.\n\n\n\nSecond paragraph.")
+    ).toBe("<p>First paragraph.</p><p>Second paragraph.</p>")
+  })
+
+  it("uses a line break for a single CRLF", () => {
+    expect(formatPlainTextToHtml("First line.\r\nSecond line.")).toBe(
+      "<p>First line.<br />Second line.</p>"
+    )
+  })
+
+  it("uses a line break for LF-only input", () => {
+    expect(formatPlainTextToHtml("First line.\nSecond line.")).toBe(
+      "<p>First line.<br />Second line.</p>"
+    )
+  })
+
+  it("formats dash, asterisk, and bullet character lists", () => {
+    expect(formatPlainTextToHtml("- One\n- Two")).toBe(
+      "<ul><li>One</li><li>Two</li></ul>"
+    )
+    expect(formatPlainTextToHtml("* One\n* Two")).toBe(
+      "<ul><li>One</li><li>Two</li></ul>"
+    )
+    expect(formatPlainTextToHtml("• One\n• Two")).toBe(
+      "<ul><li>One</li><li>Two</li></ul>"
+    )
+  })
+
+  it("keeps a lead-in paragraph and following asterisk bullets as separate runs", () => {
+    expect(formatPlainTextToHtml("What you will learn:\n* One\n* Two")).toBe(
+      "<p>What you will learn:</p><ul><li>One</li><li>Two</li></ul>"
+    )
+  })
+
+  it("keeps trailing prose after bullets as a paragraph run", () => {
+    expect(formatPlainTextToHtml("- One\n- Two\nTrailing prose.")).toBe(
+      "<ul><li>One</li><li>Two</li></ul><p>Trailing prose.</p>"
+    )
+  })
+
+  it("does not merge separate bullet runs divided by prose", () => {
+    expect(formatPlainTextToHtml("- One\nProse between runs.\n- Two")).toBe(
+      "<ul><li>One</li></ul><p>Prose between runs.</p><ul><li>Two</li></ul>"
+    )
+  })
+
+  it("escapes HTML-sensitive content exactly once", () => {
+    expect(formatPlainTextToHtml("<script>alert('x')</script>")).toBe(
+      "<p>&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;</p>"
+    )
+    expect(formatPlainTextToHtml("D&D")).toBe("<p>D&amp;D</p>")
+    expect(formatPlainTextToHtml('A "literal" quote')).toBe(
+      "<p>A &quot;literal&quot; quote</p>"
+    )
+    expect(formatPlainTextToHtml("a -> b")).toBe("<p>a -&gt; b</p>")
+  })
+
+  it("escapes content inside list items", () => {
+    expect(formatPlainTextToHtml("- <script>alert('x')</script>")).toBe(
+      "<ul><li>&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;</li></ul>"
+    )
+  })
+
+  it("does not treat emphasis or negative numbers as bullets", () => {
+    expect(formatPlainTextToHtml("*emphasis* matters")).toBe(
+      "<p>*emphasis* matters</p>"
+    )
+    expect(formatPlainTextToHtml("-5 degrees")).toBe("<p>-5 degrees</p>")
+  })
+
+  it("leaves headings and numbered lines as paragraph text", () => {
+    expect(formatPlainTextToHtml("### Heading\n1. Numbered line")).toBe(
+      "<p>### Heading<br />1. Numbered line</p>"
+    )
+  })
+})

--- a/src/utils/text-formatting.ts
+++ b/src/utils/text-formatting.ts
@@ -1,0 +1,59 @@
+export const formatPlainTextToHtml = (
+  text: string | null | undefined
+): string => {
+  if (!text) {
+    return ""
+  }
+
+  const escapedText = text
+    .replace(/\r\n?/g, "\n")
+    .trim()
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+
+  const runs: string[] = []
+
+  escapedText.split(/\n{2,}/).forEach((block) => {
+    const lines = block
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+
+    let currentKind: "bullet" | "paragraph" | null = null
+    let currentLines: string[] = []
+
+    const emitRun = () => {
+      if (currentLines.length === 0 || currentKind === null) {
+        return
+      }
+
+      if (currentKind === "bullet") {
+        runs.push(
+          `<ul>${currentLines.map((line) => `<li>${line}</li>`).join("")}</ul>`
+        )
+      } else {
+        runs.push(`<p>${currentLines.join("<br />")}</p>`)
+      }
+      currentLines = []
+    }
+
+    lines.forEach((line) => {
+      const bullet = line.match(/^[-*\u2022]\s+/)
+      const kind = bullet === null ? "paragraph" : "bullet"
+      if (kind !== currentKind) {
+        emitRun()
+        currentKind = kind
+      }
+      currentLines.push(
+        bullet === null ? line : line.replace(/^[-*\u2022]\s+/, "")
+      )
+    })
+
+    emitRun()
+  })
+
+  return runs.join("")
+}


### PR DESCRIPTION
Sessionize sends descriptions and bios as plain text (CRLF paragraphs, dash/asterisk bullets), not HTML, so dangerouslySetInnerHTML rendered everything as one flat paragraph. Convert to escaped <p>/<ul> markup before rendering instead.